### PR TITLE
Fixup string var interpolation to match naked "$var" syntax

### DIFF
--- a/Fantom.sublime-syntax
+++ b/Fantom.sublime-syntax
@@ -116,8 +116,6 @@ contexts:
     - scope: variable.other.interpolated-expr.fan
       match: '\$\{.+?\}'
     - scope: variable.other.interpolated-expr.fan
-      match: '\$({{ident}})'
-    - scope: variable.other.interpolated-dotcall.fan
       match: '\$({{ident}}(\.{{ident}})*)'
     - scope: invalid.illegal.interpolation.fan
       match: '\$\{\w*'

--- a/Fantom.sublime-syntax
+++ b/Fantom.sublime-syntax
@@ -115,6 +115,8 @@ contexts:
   interpolation:
     - scope: variable.other.interpolated-expr.fan
       match: '\$\{.+?\}'
+    - scope: variable.other.interpolated-expr.fan
+      match: '\$({{ident}}({{ident}})*)'
     - scope: variable.other.interpolated-dotcall.fan
       match: '\$({{ident}}(\.{{ident}})*)'
     - scope: invalid.illegal.interpolation.fan

--- a/Fantom.sublime-syntax
+++ b/Fantom.sublime-syntax
@@ -116,7 +116,7 @@ contexts:
     - scope: variable.other.interpolated-expr.fan
       match: '\$\{.+?\}'
     - scope: variable.other.interpolated-expr.fan
-      match: '\$({{ident}}({{ident}})*)'
+      match: '\$({{ident}})'
     - scope: variable.other.interpolated-dotcall.fan
       match: '\$({{ident}}(\.{{ident}})*)'
     - scope: invalid.illegal.interpolation.fan


### PR DESCRIPTION
Actually, this was already working, but a different scope name was getting
generated for "naked" dot calls which was confusing when trying to apply
syntax coloring

Proposing to use the same scope name for both variations to simplify.